### PR TITLE
Docusaurus support for math equations

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,9 @@
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
+const math = require('remark-math');
+const katex = require('rehype-katex');
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
 	title: 'Primitive',
@@ -25,6 +28,8 @@ const config = {
 					path: 'docs/concepts',
 					routeBasePath: 'concepts/',
 					sidebarPath: require.resolve('./sidebars.js'),
+					remarkPlugins: [math],
+					rehypePlugins: [katex],
 				},
 				blog: {
 					showReadingTime: true,
@@ -56,7 +61,13 @@ const config = {
 			}
 		],
 	],
-
+	stylesheets: [
+		{
+			href: "https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css",
+			integrity: "sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc",
+			crossorigin: "anonymous",
+		},
+	],
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({

--- a/package.json
+++ b/package.json
@@ -20,9 +20,12 @@
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",
+    "hast-util-is-element": "^1.1.0",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "rehype-katex": "^4.0.0",
+    "remark-math": "^3.0.1",
     "url-loader": "^4.1.1"
   },
   "browserslist": {


### PR DESCRIPTION
I saw that the Uniswap trading function did not render.

This PR adds Docusaurus support for (latex) math equations and thereby fixes the rendering issue in `docs/concepts/01-overview.md`