### PR TITLE
Concepts section: Link to whitepaper fix

### DIFF
--- a/docs/concepts/06-advanced.md
+++ b/docs/concepts/06-advanced.md
@@ -12,7 +12,7 @@ Take this you'll need it...
 
 ### Primitive RMM-01 Whitepaper
 
-[Whitepaper](https://primitive.finance/whitepaper)
+[Whitepaper](https://primitive.finance/whitepaper-rmm-01.pdf)
 
 ### Maths
 


### PR DESCRIPTION
[Concepts Advanced](https://docs.primitive.finance/concepts/advanced) has a broken link. This is a fix.